### PR TITLE
Use warn when capturing

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,14 +17,13 @@ if (process.env.NODE_ENV === 'production') {
 } else {
 	module.exports = {
 		captureMessage: function () {
-			logger.error.apply(logger, arguments);
+			logger.warn.apply(logger, arguments);
 		},
 		captureError: function () {
-			logger.error.apply(logger, arguments);
+			logger.warn.apply(logger, arguments);
 		},
 		middleware: function(err, req, res, next) {
-			logger.error("Uncaught Error", err);
-			logger.error(err.stack);
+			logger.error("Uncaught Error -", err);
 			res.status(500).send({ type: "Uncaught Error", error: err });
 			process.exit(1);
 		}


### PR DESCRIPTION
Feels like if it's been captured and sent, it shouldn't be a full blown error

Also, don't repeat the error logging