### PR TITLE
Smarter capture error

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,9 +41,20 @@ function getUpstreamErrorHandler (errorReporter) {
 	};
 }
 
+function getCaptureError (client) {
+	return function(err) {
+		if (err.name === fetchres.ReadTimeoutError.name) {
+			logger.error('event=dependencytimeout', err);
+		} else {
+			client.captureError.apply(client, arguments);
+		}
+	};
+}
+
 if (process.env.NODE_ENV === 'production') {
 	const client = new raven.Client(process.env.RAVEN_URL);
-	module.exports = client;
+	module.exports = Object.assign({}, client);
+	module.exports.captureError = getCaptureError(client);
 	module.exports.middleware = sendErrorProd;
 	module.exports.upstreamErrorHandler = getUpstreamErrorHandler(sendErrorProd);
 	ravenMiddleware = raven.middleware.express(client);

--- a/test/dev.spec.js
+++ b/test/dev.spec.js
@@ -44,7 +44,7 @@ describe('express errors handler in dev', function () {
 			.get('/caught-error')
 			.end((err, res) => {
 				expect(res.status).to.equal(500);
-				expect(logger.error.calledWith('event=uncaughterror', error))
+				expect(logger.error.calledWith('event=uncaughterror', error)).to.be.true;
 				done();
 			});
 	});
@@ -54,7 +54,7 @@ describe('express errors handler in dev', function () {
 			.get('/timeout')
 			.end((err, res) => {
 				expect(res.status).to.equal(504);
-				expect(logger.error.calledWith('event=dependencytimeout', readTimeoutError))
+				expect(logger.error.calledWith('event=dependencytimeout', readTimeoutError)).to.be.true;
 				done();
 			});
 	});
@@ -64,7 +64,7 @@ describe('express errors handler in dev', function () {
 			.get('/bad-response')
 			.end((err, res) => {
 				expect(res.status).to.equal(513);
-				expect(logger.error.calledWith('event=uncaughterror', badServerError))
+				expect(logger.error.calledWith('event=uncaughterror', badServerError)).to.be.true;
 				done();
 			});
 	});
@@ -74,7 +74,7 @@ describe('express errors handler in dev', function () {
 			.get('/not-bad-response')
 			.end((err, res) => {
 				expect(res.status).to.equal(500);
-				expect(logger.error.calledWith('event=uncaughterror', error))
+				expect(logger.error.calledWith('event=uncaughterror', error)).to.be.true;
 				done();
 			});
 	});

--- a/test/prod.spec.js
+++ b/test/prod.spec.js
@@ -8,7 +8,7 @@ const logger = require('ft-next-logger').logger;
 const sinon = require('sinon');
 const raven = require('raven');
 
-describe('express errors handler in dev', function () {
+describe('express errors handler in prod', function () {
 	let app;
 	let errorsHandler;
 	const readTimeoutError = new fetchres.ReadTimeoutError();
@@ -17,9 +17,16 @@ describe('express errors handler in dev', function () {
 	const ravenSpy = sinon.spy(function (err, req, res, next) {
 		next(err, req, res);
 	});
+	const captureErrorSpy = sinon.spy();
 
 	before(function () {
 		sinon.stub(raven.middleware, 'express', () => ravenSpy);
+		sinon.stub(raven, 'Client', () => {
+			return {
+				captureError: captureErrorSpy,
+				patchGlobal: sinon.spy()
+			}
+		});
 		errorsHandler = require('../main');
 		app = express();
 
@@ -52,7 +59,7 @@ describe('express errors handler in dev', function () {
 			.get('/caught-error')
 			.end((err, res) => {
 				expect(res.status).to.equal(500);
-				expect(logger.error.calledWith('event=uncaughterror', error));
+				expect(logger.error.calledWith('event=uncaughterror', error)).to.be.false;
 				expect(ravenSpy.called).to.be.true;
 				expect(ravenSpy.args[0].length).to.equal(4);
 				done();
@@ -65,7 +72,7 @@ describe('express errors handler in dev', function () {
 			.end((err, res) => {
 				expect(res.status).to.equal(504);
 				expect(ravenSpy.called).to.be.false;
-				expect(logger.error.calledWith('event=dependencytimeout', readTimeoutError))
+				expect(logger.error.calledWith('event=dependencytimeout', readTimeoutError)).to.be.true;
 				done();
 			});
 	});
@@ -76,7 +83,7 @@ describe('express errors handler in dev', function () {
 			.end((err, res) => {
 				expect(res.status).to.equal(513);
 				expect(ravenSpy.called).to.be.false;
-				expect(logger.error.calledWith('event=uncaughterror', badServerError))
+				expect(logger.error.calledWith('event=uncaughterror', badServerError)).to.be.true;
 				done();
 			});
 	});
@@ -88,9 +95,18 @@ describe('express errors handler in dev', function () {
 				expect(res.status).to.equal(500);
 				expect(ravenSpy.called).to.be.true;
 				expect(ravenSpy.args[0].length).to.equal(4);
-				expect(logger.error.calledWith('event=uncaughterror', error))
+				expect(logger.error.calledWith('event=uncaughterror', error)).to.be.false;
 				done();
 			});
 	});
 
+	it('can capture errors outside of express controllers', function () {
+		errorsHandler.captureError(readTimeoutError);
+		expect(logger.error.calledWith('event=dependencytimeout', readTimeoutError)).to.be.true;
+
+		errorsHandler.captureError(badServerError);
+		expect(captureErrorSpy.called).to.be.true;
+		expect(captureErrorSpy.args[0].length).to.equal(1);
+		expect(captureErrorSpy.args[0][0].name).to.equal(badServerError.name);
+	});
 });

--- a/test/prod.spec.js
+++ b/test/prod.spec.js
@@ -18,12 +18,14 @@ describe('express errors handler in prod', function () {
 		next(err, req, res);
 	});
 	const captureErrorSpy = sinon.spy();
+	const captureMessageSpy = sinon.spy();
 
 	before(function () {
 		sinon.stub(raven.middleware, 'express', () => ravenSpy);
 		sinon.stub(raven, 'Client', () => {
 			return {
 				captureError: captureErrorSpy,
+				captureMessage: captureMessageSpy,
 				patchGlobal: sinon.spy()
 			}
 		});
@@ -108,5 +110,13 @@ describe('express errors handler in prod', function () {
 		expect(captureErrorSpy.called).to.be.true;
 		expect(captureErrorSpy.args[0].length).to.equal(1);
 		expect(captureErrorSpy.args[0][0].name).to.equal(badServerError.name);
+	});
+
+	it('can capture messages outside of express controllers', function () {
+		errorsHandler.captureMessage('random message');
+
+		expect(captureMessageSpy.called).to.be.true;
+		expect(captureMessageSpy.args[0].length).to.equal(1);
+		expect(captureMessageSpy.args[0][0]).to.equal('random message');
 	});
 });


### PR DESCRIPTION
/cc @wheresrhys @matthew-andrews 

As discussed [here](https://github.com/Financial-Times/next-graphql-api/pull/18), wrapping captureError to give some of the smartness that the middleware gets.

Also fixing some false positives in the tests.