### PR TITLE
Fix errorsHandler.captureMessage is not a function

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,20 +42,21 @@ function getUpstreamErrorHandler (errorReporter) {
 	};
 }
 
-function getCaptureError (client) {
+function getCaptureError (client, _captureError) {
 	return function(err) {
 		if (err.name === fetchres.ReadTimeoutError.name) {
 			logger.error('event=dependencytimeout', err);
 		} else {
-			client.captureError.apply(client, arguments);
+			_captureError.apply(client, arguments);
 		}
 	};
 }
 
 if (process.env.NODE_ENV === 'production') {
 	const client = new raven.Client(process.env.RAVEN_URL);
-	module.exports = Object.assign({}, client);
-	module.exports.captureError = getCaptureError(client);
+	const _captureError = client.captureError;
+	module.exports = client;
+	module.exports.captureError = getCaptureError(client, _captureError);
 	module.exports.middleware = sendErrorProd;
 	module.exports.upstreamErrorHandler = getUpstreamErrorHandler(sendErrorProd);
 	ravenMiddleware = raven.middleware.express(client);

--- a/test/prod.spec.js
+++ b/test/prod.spec.js
@@ -22,13 +22,13 @@ describe('express errors handler in prod', function () {
 
 	before(function () {
 		sinon.stub(raven.middleware, 'express', () => ravenSpy);
-		sinon.stub(raven, 'Client', () => {
-			return {
-				captureError: captureErrorSpy,
-				captureMessage: captureMessageSpy,
-				patchGlobal: sinon.spy()
-			}
-		});
+
+		const clientStub = function() {};
+		clientStub.prototype.captureMessage = captureMessageSpy;
+		clientStub.prototype.captureError = captureErrorSpy;
+		clientStub.prototype.patchGlobal = sinon.spy();
+
+		sinon.stub(raven, 'Client', clientStub);
 		errorsHandler = require('../main');
 		app = express();
 
@@ -50,11 +50,12 @@ describe('express errors handler in prod', function () {
 		app.use(errorsHandler.middleware);
 	});
 
+
 	beforeEach(() => sinon.stub(logger, 'error'));
 	afterEach(() => {
 		logger.error.restore();
 		ravenSpy.reset();
-	})
+	});
 
 	it('handle an arbitrary error', function (done) {
 		request(app)


### PR DESCRIPTION
/cc @wheresrhys @charypar @ironsidevsquincy

`Object.assign` would lose the functions on Client.prototype - which meant that `captureMessage` wouldn't be exported.


 (and update test to fail with old code)